### PR TITLE
list_formのエラー発生の一時的修正

### DIFF
--- a/js/doLinkKougi.js
+++ b/js/doLinkKougi.js
@@ -2,13 +2,15 @@ $(function () {
   const BASE_NOTIFY_URL = "https://lms.ynu.ac.jp/lms/infrInfl/doIndex;SID=";
   const s_id = location.href.split("SID=")[1];
   let form = main();
+
   async function main() {
     const rawRes = await fetch(BASE_NOTIFY_URL + s_id);
     const resHtml = await rawRes.text();
     const parser = new DOMParser();
     const infoDocument = parser.parseFromString(resHtml, "text/html");
-    console.log(infoDocument.getElementById("list_form"));
     let aaa = infoDocument.getElementById("list_form");
+    console.log(aaa);
+    if (aaa === null) return
     // return infoDocument.getElementById("list_form");
     $.ajax({
       type: "POST",


### PR DESCRIPTION
# 発生していた問題
`list_form` 要素を取得して通信処理を行っている部分において、 `list_form` が見つからなかった場合も通信処理が行われエラーが発生しまっていた。

# 対処
`list_form` の取得でエラーが発生していたので一時的に、 `list_form` が存在しない場合は処理を行わないという実装にて修正しました。